### PR TITLE
환경변수 경로 수정, 결제 취소 기능

### DIFF
--- a/src/pages/Payment/Payment.js
+++ b/src/pages/Payment/Payment.js
@@ -14,7 +14,7 @@ const getEnvVariable = (key) => {
     return process.env[key];
 };
 
-const API_BASE_URL = getEnvVariable('REACT_APP_API_BASE_URL');
+const API_BASE_URL = getEnvVariable('REACT_APP_BASE_URL');
 const BOOTPAY_WEB_APPLICATION_ID = getEnvVariable('REACT_APP_BOOTPAY_WEB_APPLICATION_ID');
 
 async function fetchAllPaymentData(size = 1000) {
@@ -52,6 +52,25 @@ async function requestPaymentApprovalToBackend(receiptId, amount, paymentMethod,
         let errorMessage = '결제 처리 중 오류 발생';
         if (error.response) {
             errorMessage = `백엔드 결제 승인 실패: ${error.response.data.message || error.response.statusText}`;
+        } else {
+            errorMessage = `네트워크 오류: ${error.message}`;
+        }
+        alert(errorMessage);
+        throw new Error(errorMessage);
+    }
+}
+
+async function requestPaymentCancelToBackend(paymentId) {
+    const apiUrl = `${API_BASE_URL}/mojadol/api/v1/payment/detail/${paymentId}`;
+
+    try {
+        const response = await axiosInstance.post(apiUrl); // POST 요청으로 변경
+        return response.data.result;
+    } catch (error) {
+        console.error(`결제 ID ${paymentId} 취소 중 오류 발생:`, error);
+        let errorMessage = '결제 취소 처리 중 오류 발생';
+        if (error.response) {
+            errorMessage = `결제 취소 실패: ${error.response.data.message || error.response.statusText}`;
         } else {
             errorMessage = `네트워크 오류: ${error.message}`;
         }
@@ -304,6 +323,30 @@ function Payment() {
         setSelectedProduct(product);
     };
 
+    const handleCancelPayment = async (paymentId, title, amount, voucher) => {
+        // 이미 사용된 이용권인지 확인 (프론트엔드 단에서 최대한의 필터링)
+        // 백엔드에서 voucher.usedCount를 제공하지 않으므로,
+        // completed === 1 이면서 voucher가 null이 아닌 경우, 그리고 totalCount가 0보다 큰 경우에만 취소 가능하다고 가정합니다.
+        // 실제 사용 여부는 백엔드에서 정확히 판단해야 합니다.
+        if (voucher && voucher.totalCount > 0 && !window.confirm(`${title} (${amount.toLocaleString()}원) 결제를 취소하시겠습니까?`)) {
+            return;
+        } else if (!voucher && !window.confirm(`${title} (${amount.toLocaleString()}원) 결제를 취소하시겠습니까?`)) {
+            return;
+        }
+
+        setLoading(true);
+        try {
+            await requestPaymentCancelToBackend(paymentId);
+            alert('결제가 성공적으로 취소되었습니다.');
+            loadInitialData(); // 취소 후 데이터 새로고침
+        } catch (error) {
+            console.error('결제 취소 실패:', error);
+            alert(`결제 취소에 실패했습니다: ${error.message}`);
+        } finally {
+            setLoading(false);
+        }
+    };
+
     // 로딩 중일 때 로딩 메시지와 스피너 표시
     if (loading) {
         return (
@@ -440,9 +483,9 @@ function Payment() {
                                 <tr>
                                     <th>일시</th>
                                     <th>이용권 명</th>
-                                    <th>구매 개수</th>
                                     <th>결제 금액</th>
                                     <th>결제 수단</th>
+                                    <th>관리</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -450,9 +493,23 @@ function Payment() {
                                     <tr key={index}>
                                         <td>{payment.paymentDate ? payment.paymentDate.split('T')[0] : ''}</td>
                                         <td>{payment.title}</td>
-                                        <td className="align-right">{payment.voucher ? payment.voucher.totalCount : 0}</td>
+                                        {/*<td className="align-right">{payment.voucher ? payment.voucher.totalCount : 0}</td>*/}
                                         <td className="align-right">{payment.amount ? payment.amount.toLocaleString() : 0}원</td>
                                         <td>{payment.paymentMethod}</td>
+                                        <td>
+                                            {payment.completed === 1 && payment.voucher && payment.voucher.totalCount > 0 ? (
+                                                <button
+                                                    className="cancel-payment-button"
+                                                    onClick={() => handleCancelPayment(payment.paymentId, payment.title, payment.amount, payment.voucher)}
+                                                >
+                                                    취소
+                                                </button>
+                                            ) : (
+                                                <button className="cancel-payment-button" disabled>
+                                                    취소 불가
+                                                </button>
+                                            )}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>


### PR DESCRIPTION
제가 이용권 10개를 구매해서 2개를 쓰고 현재 8개가 남았다면
결제 내역 표에는 구매했던 이용권 개수: 10개
이용권 정보 표에서는 잔여 개수: 8개 
이런식으로 뜨게 하고 싶었는데 payment.voucher.totalCount로 현재 남은 이용권 개수만 받아올 수 있더라고요 (구매했던  처음의 이용권 개수는 저장되지 않음) 그래서 그냥 처음 구매했던 개수(10개)는 표시하지 않기로 했어요. 
대신 구매할 때 이용권 이름을 'GOLD이용권(10개)', 'GOLD이용권(100개)' 이런식으로 개수랑 같이 설정해둬서 괜찮을 거 같다고 생각해요. 

문제는 결제 취소 기능을 추가하려고 할 때 이미 이용권을 사용했다면 취소가 불가능해야하는데 처음 이용권 개수가 저장된 게 없으니 막기가 애매해요. 일단은 그냥 totalCount 가 0보다 크면 취소버튼 활성화 이런식이에요. 그래서 제가 이용권 10개 중 8개 사용하고 2개가 남아도 취소 버튼을 누를 수가 있어요

그리고 지금은 취소가 그냥 안 됩니다.  
*결제 취소(환불)**는 일반적으로 다음과 같은 이유로 백엔드를 통해서만 처리하는 것이 일반적이고 보안상 안전합니다.

보안:
결제를 취소하려면 해당 결제에 대한 관리자 권한이나 최소한 취소 권한이 필요합니다.
프론트엔드에서 직접 취소 요청을 보내면, 필요한 인증 정보나 API 키 등이 노출될 위험이 있습니다.
환불 금액 조작 등 악의적인 시도를 막기 위해 서버에서 환불 로직을 엄격하게 통제해야 합니다.
데이터 무결성:
환불은 재고 관리, 이용권 소멸 처리, 회계 처리 등 복잡한 비즈니스 로직과 연관되어 있습니다.
이러한 로직은 백엔드에서 데이터베이스와 연동하여 안전하게 처리되어야 합니다. 프론트엔드에서 직접 처리하면 데이터 불일치나 오류가 발생할 가능성이 높습니다.
부트페이 정책 및 기능:
부트페이의 결제 취소(환불) API는 일반적으로 서버 API 키를 사용하여 호출해야 합니다. 이 서버 API 키는 외부에 노출되어서는 안 됩니다. 따라서 프론트엔드에서는 직접 호출할 수 없고, 백엔드를 통해 간접적으로 호출해야 합니다.
부트페이 SDK(BootPay.request)는 주로 결제를 시작하고 완료하는 데 사용되며, 이미 완료된 결제를 취소하는 직접적인 기능은 제공하지 않습니다. 취소는 부트페이의 REST API를 통해 이루어집니다.
