### PR TITLE
마이페이지

### DIFF
--- a/src/pages/mypage/mypage.js
+++ b/src/pages/mypage/mypage.js
@@ -1,68 +1,108 @@
-import React, { createElement as h, useState } from 'react';
-import axios from 'axios';
+import React, { createElement as h, useState, useEffect } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import './mypage.css';
+import axiosInstance from '../../lib/axiosInstance';
+import { getEnv } from '../../lib/getEnv';
 
-const BASE_URL = 'https://myeonjub.store/api'; // 
+const API_BASE_URL = getEnv('REACT_APP_BASE_URL');
 
 function MyPage() {
   const [showModal, setShowModal] = useState(false);
-  const [password, setPassword] = useState('');
+  const [password, setPassword] = useState(''); // 개인정보 수정 시 사용될 새/현재 비밀번호
   const [isEditable, setIsEditable] = useState(false);
-
-  const [emailDomain, setEmailDomain] = useState('');
-  const [selectedDomain, setSelectedDomain] = useState('직접입력');
+  const [email, setEmail] = useState(''); 
   const [marketingAgreed, setMarketingAgreed] = useState(true);
 
-  const [email, setEmail] = useState('');
-  const [username, setUsername] = useState(''); 
-  const [name, setName] = useState('');         
+  const [username, setUsername] = useState('');
+  const [name, setName] = useState('');
   const [nickname, setNickname] = useState('');
+  const [originalNickname, setOriginalNickname] = useState(''); 
 
-  const [emailMsg, setEmailMsg] = useState('');
   const [passwordMsg, setPasswordMsg] = useState('');
+  const [nicknameMsg, setNicknameMsg] = useState(''); // 닉네임 중복 체크 메시지
 
-  // 비밀번호 유효성 검사
-  const validatePassword = (pw) => {
-    const regex = /^[0-9]+$/;
-    return regex.test(pw);
-  };
-
-  // 이메일 유효성 검사
-  const validateEmail = (email) => {
-    const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return regex.test(email);
-  };
-
-  // 비밀번호 확인
-  const handleConfirm = async () => {
-    try {
-      const token = localStorage.getItem('token');
-
-      await axios.post(`${BASE_URL}/mojadol/api/v1/auth/signOut`, {}, {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        withCredentials: true,
-      });
-
-
-      const response = await axios.post(`${BASE_URL}/mojadol/api/v1/mypage/checkPassword`,
-        { userPw: password },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+  // 컴포넌트 마운트 시 사용자 정보 불러오기
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await axiosInstance.get(`${API_BASE_URL}/mojadol/api/v1/mypage/profile`);
+        if (response.data.isSuccess) {
+          const userData = response.data.result;
+          setName(userData.userName);
+          setUsername(userData.userLoginId);
+          setNickname(userData.nickname);
+          setOriginalNickname(userData.nickname);
+          setEmail(userData.email); 
+        } else {
+          toast.error('사용자 정보를 불러오는데 실패했습니다: ' + response.data.message);
         }
+      } catch (error) {
+        console.error('사용자 정보 불러오기 에러:', error);
+        toast.error('사용자 정보를 불러오는 중 오류가 발생했습니다.');
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  // 닉네임 중복 체크 (debounce 적용)
+  useEffect(() => {
+    const debounceNicknameCheck = setTimeout(async () => {
+      // isEditable 상태에서만 닉네임 중복 체크를 수행
+      // 닉네임이 비어있거나 공백만 있는 경우 중복 체크를 하지 않음
+      if (isEditable && nickname && nickname.trim() !== '') {
+        if (nickname === originalNickname) {
+          setNicknameMsg(''); // 메시지를 비워 유효한 상태로 만듭니다.
+          return; // API 호출을 건너뜁니다.
+        }
+        try {
+          const response = await axiosInstance.get(`${API_BASE_URL}/mojadol/api/v1/users/check`, {
+            params: { nickname: nickname },
+          });
+
+          if (response.data.result === '중복되는 데이터가 없습니다.') {
+            setNicknameMsg('사용 가능한 닉네임입니다.');
+          } else {
+            setNicknameMsg('이미 사용 중인 닉네임입니다.');
+          }
+
+        } catch (error) {
+          console.error('닉네임 중복 확인 에러:', error);
+          setNicknameMsg('닉네임 중복 확인 중 오류가 발생했습니다.'); 
+        }
+      } else {
+        setNicknameMsg(''); // 닉네임이 비어있거나 수정 모드가 아니면 메시지 초기화
+      }
+    }, 500); // 500ms debounce
+
+    return () => clearTimeout(debounceNicknameCheck);
+  }, [nickname, isEditable, originalNickname]); // isEditable이 변경될 때도 useEffect 재실행
+
+  const validatePassword = (pw) => {
+    const lengthCheck = /^.{8,16}$/;
+    const types = [/[A-Z]/, /[a-z]/, /[0-9]/, /[^A-Za-z0-9]/]; 
+    const passedTypes = types.filter((regex) => regex.test(pw)).length; 
+    return lengthCheck.test(pw) && passedTypes >= 2; 
+  };
+
+  // 비밀번호 확인 (개인정보 수정 진입 전)
+  const handleConfirm = async () => {
+    if (!password) {
+      toast.error('비밀번호를 입력해주세요.');
+      return;
+    }
+
+    try {
+      const response = await axiosInstance.post(`${API_BASE_URL}/mojadol/api/v1/mypage/check-password`,
+        { userPw: password }
       );
 
-      if (response.data.isSuccess) {
-        setIsEditable(true);
-        setShowModal(false);
+      if (response.data.isSuccess && response.data.result === '비밀번호가 일치합니다.') {
+        setIsEditable(true); // 수정 모드 활성화
+        setShowModal(false); // 모달 닫기
         toast.success('개인정보를 수정할 수 있습니다.');
+        setPassword(''); // 비밀번호 확인 후 모달 비밀번호 필드 초기화 (수정 모드 진입 후 새 비밀번호 입력 위함)
       } else {
         toast.error('비밀번호가 올바르지 않습니다.');
       }
@@ -74,38 +114,42 @@ function MyPage() {
 
   // 개인정보 수정 저장
   const handleUpdateProfile = async () => {
-    if (!validatePassword(password)) {
-      setPasswordMsg('비밀번호는 숫자만 포함해야 합니다.');
-      return;
+    // 닉네임이 변경되었고, 그 닉네임이 '이미 사용 중인 닉네임'이라는 메시지를 띄우고 있다면 저장 불가
+    if (nickname !== originalNickname && nicknameMsg === '이미 사용 중인 닉네임입니다.') {
+        toast.error('이미 사용 중인 닉네임으로 변경할 수 없습니다.');
+        return;
+    }
+    // 닉네임이 변경되었는데 비어있는 경우 (추가적인 유효성 검사)
+    if (isEditable && nickname.trim() === '') {
+        toast.error('닉네임을 입력해주세요.');
+        return;
     }
 
-    const fullEmail = `${email}@${emailDomain}`;
-    if (!validateEmail(fullEmail)) {
-      setEmailMsg('올바른 이메일 형식이 아닙니다.');
+    // 비밀번호 필수가 되었으므로, 비밀번호 유효성 검사
+    if (!password) {
+      setPasswordMsg('비밀번호를 반드시 입력해야 합니다.');
       return;
     }
+    if (!validatePassword(password)) {
+      setPasswordMsg('비밀번호는 8~16자리의 대소문자/숫자/특수문자 2종 이상을 조합해야 합니다.');
+      return;
+    } else {
+      setPasswordMsg('');
+    }
+
+    const payload = {
+      nickname: nickname,
+      userPw: password, 
+    };
 
     try {
-      const token = localStorage.getItem('token');
-
-      const response = await axios.post(`${BASE_URL}/mojadol/api/v1/mypage/updateProfile`,
-        {
-          userPw: password,
-          nickname: nickname,
-          email: fullEmail,
-          marketingAgree: marketingAgreed,
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+      const response = await axiosInstance.patch(`${API_BASE_URL}/mojadol/api/v1/mypage/update-profile`, payload);
 
       if (response.data.isSuccess) {
         toast.success('개인정보 수정이 완료되었습니다.');
-        setIsEditable(false);
+        setIsEditable(false); 
+        setPassword(''); 
+        setOriginalNickname(nickname); // 수정 성공하면 originalNickname도 업데이트트
       } else {
         toast.error('개인정보 수정 실패: ' + response.data.message);
       }
@@ -121,20 +165,13 @@ function MyPage() {
     if (!confirmWithdraw) return;
 
     try {
-      const token = localStorage.getItem('token');
-
-      const response = await axios.post(`${BASE_URL}/mojadol/api/v1/mypage/resignUser`, {}, {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await axiosInstance.delete(`${API_BASE_URL}/mojadol/api/v1/mypage/resign`);
 
       if (response.data.isSuccess) {
-        toast.success('회원 탈퇴가 완료되었습니다.');
+        toast.success('회원 탈퇴 예약이 완료되었습니다.');
         localStorage.removeItem('token');
         setTimeout(() => {
-          window.location.href = '/';
+          window.location.href = '/'; // 홈으로 리다이렉트
         }, 1500);
       } else {
         toast.error('회원 탈퇴 실패: ' + response.data.message);
@@ -145,8 +182,8 @@ function MyPage() {
     }
   };
 
-
-  const inputRow = (label, value, setValue, type = 'text', disabled = false) =>
+  // input 행을 렌더링하는 헬퍼 함수
+  const inputRow = (label, value, setValue, type = 'text', disabled = false, msg = '') =>
     h('div', { className: 'form-row' },
       h('div', { className: 'form-label' }, label),
       h('div', { className: 'form-input' },
@@ -155,16 +192,15 @@ function MyPage() {
           value,
           disabled,
           onChange: (e) => setValue(e.target.value),
-        })
+        }),
+        msg && h('div', { style: { fontSize: '13px', color: '#ef4444', marginTop: '5px' } }, msg)
       )
     );
 
   return h('main', { className: 'content' },
     h('h1', null, '개인정보 관리'),
 
-
     h('div', { className: 'top-buttons' },
-      h('button', { className: 'date-button' }, '이용권 만료 일자 2025.03.01'),
       !isEditable && h('button', { className: 'edit-button', onClick: () => setShowModal(true) }, '개인정보수정'),
       isEditable && h('button', { className: 'save-button', onClick: handleUpdateProfile }, '저장하기')
     ),
@@ -172,45 +208,10 @@ function MyPage() {
     h('form', { className: 'form-table' },
       inputRow('이름', name, setName, 'text', true),
       inputRow('아이디', username, setUsername, 'text', true),
-      inputRow('별명', nickname, setNickname, 'text', !isEditable),
-
-      h('div', { className: 'form-row' },
-        h('div', { className: 'form-label' }, '이메일'),
-        h('div', { className: 'form-input row-flex' },
-          h('input', {
-            type: 'text',
-            disabled: !isEditable,
-            value: email,
-            onChange: (e) => setEmail(e.target.value),
-          }),
-          h('span', null, '@'),
-          h('input', {
-            type: 'text',
-            disabled: !isEditable || selectedDomain !== '직접입력',
-            value: emailDomain,
-            onChange: (e) => setEmailDomain(e.target.value),
-          }),
-          h('select', {
-            disabled: !isEditable,
-            value: selectedDomain,
-            onChange: (e) => {
-              const value = e.target.value;
-              setSelectedDomain(value);
-              setEmailDomain(value !== '직접입력' ? value : '');
-            }
-          },
-            ['직접입력', 'gmail.com', 'naver.com'].map((domain, idx) =>
-              h('option', { key: idx, value: domain }, domain)
-            )
-          )
-        )
-      ),
-      h('div', { style: { fontSize: '13px', color: '#ef4444', marginBottom: '10px' } }, emailMsg),
-
-      inputRow('비밀번호', password, setPassword, 'password', !isEditable),
-      h('div', { style: { fontSize: '13px', color: '#ef4444', marginBottom: '10px' } }, passwordMsg),
-
-   
+      inputRow('별명', nickname, setNickname, 'text', !isEditable, nicknameMsg),
+      inputRow('이메일', email, setEmail, 'text', true), 
+      
+      inputRow('비밀번호', password, setPassword, 'password', !isEditable, passwordMsg),
 
       h('div', { className: 'form-row toggle-row' },
         h('div', { className: 'form-label' }, '마케팅 정보 수신'),
@@ -219,23 +220,22 @@ function MyPage() {
             h('input', {
               type: 'checkbox',
               checked: marketingAgreed,
-
-              onChange: () => setMarketingAgreed(!marketingAgreed) 
-
+              disabled: !isEditable,
+              onChange: () => setMarketingAgreed(!marketingAgreed)
             }),
             h('span', { className: 'toggle-slider' })
           )
         )
-      )      
+      )
     ),
-        
+
     h('div', { className: 'fixed-withdraw' },
       h('button', { className: 'withdraw-button', onClick: handleWithdraw }, '회원 탈퇴')
     ),
 
     showModal && h('div', { className: 'modal' },
       h('div', { className: 'modal-content' },
-        h('p', null, '비밀번호를 입력하세요'),
+        h('p', null, '개인정보 수정을 위해 비밀번호를 입력해주세요.'),
         h('input', {
           type: 'password',
           value: password,
@@ -244,7 +244,7 @@ function MyPage() {
         }),
         h('div', { className: 'modal-actions' },
           h('button', { onClick: handleConfirm }, '확인'),
-          h('button', { onClick: () => setShowModal(false) }, '취소')
+          h('button', { onClick: () => { setShowModal(false); setPassword(''); } }, '취소') // 취소 시 비밀번호 초기화
         )
       )
     ),
@@ -254,4 +254,3 @@ function MyPage() {
 }
 
 export default MyPage;
-


### PR DESCRIPTION
계속 봤는데 회원 수정 (patch,/mojadol/api/v1/mypage/update-profile) 이거 무조건 "userPw"랑"nickname"을 받더라고요
비밀번호만 변경하는 경우에는 닉네임은 /mypage/profile 로 받아와지니까 그 초기값을 저장해놓고 닉네임이 변경되지 않은 경우 바뀐 비밀번호랑 같이 그 닉네임 초기값을 같이 붙여서 전송하면 되는데 
닉네임만 변경하는 경우가 안 됩니다. 비밀번호는 초기값을 받아와서 저장할 수가 없으니 닉네임만 바꾸고 싶어도 무조건 비밀번호도 입력해야해요. 
혹시나 비밀번호를 "" 공백으로 줘 봤더니 진짜 비밀번호가 공백이 돼버리더라고요 당연한 소리지만..
수정 가능하시면 닉네임만 수정된 경우여도 저장될 수 있도록 따로따로 받을 수 있게 부탁드려도될까요? 아니면 프론트에서 '닉네임만 변경해도 비밀번호 입력하셔야 저장됩니다.' 이런식으로 화면을 바꾸든지 할게요!
회원탈퇴는 진짜 계정이삭제되는게아니라 '삭제요청이완료되었습니다'이런값만오던데 맞나요? 일단 로그아웃하고 홈으로 이동하게만 해놨어요.